### PR TITLE
Fix yaml services config for symfony 3 upgrade

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,23 +2,23 @@ services:
     anime_db.ani_db.browser:
         class: AnimeDb\Bundle\AniDbBrowserBundle\Service\Browser
         arguments:
-            - @anime_db.ani_db.browser.client
-            - %anime_db.ani_db.host%
-            - %anime_db.ani_db.api.prefix%
-            - %anime_db.ani_db.api.client%
-            - %anime_db.ani_db.api.clientver%
-            - %anime_db.ani_db.api.protover%
-            - %anime_db.ani_db.app_code%
-            - %anime_db.ani_db.image_prefix%
+            - '@anime_db.ani_db.browser.client'
+            - '%anime_db.ani_db.host%'
+            - '%anime_db.ani_db.api.prefix%'
+            - '%anime_db.ani_db.api.client%'
+            - '%anime_db.ani_db.api.clientver%'
+            - '%anime_db.ani_db.api.protover%'
+            - '%anime_db.ani_db.app_code%'
+            - '%anime_db.ani_db.image_prefix%'
         calls:
-            - [ setResponseCache, [ @anime_db.ani_db.browser.cache ] ]
+            - [ setResponseCache, [ '@anime_db.ani_db.browser.cache' ] ]
 
     anime_db.ani_db.browser.client:
         class: Guzzle\Http\Client
-        arguments: [ %anime_db.ani_db.api.host% ]
+        arguments: [ '%anime_db.ani_db.api.host%' ]
         public: false
 
     anime_db.ani_db.browser.cache:
         class: AnimeDb\Bundle\AniDbBrowserBundle\Service\CacheResponse
-        arguments: [ %anime_db.ani_db.cache_response_dir% ]
+        arguments: [ '%anime_db.ani_db.cache_response_dir%' ]
         public: false


### PR DESCRIPTION
https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#yaml

But there is still bug, cause current bundle use depricated guzzle version 3.9.* and it depends on symfony/event-dispatcher ~2.1, witch coouldn`t update up to symfony version 3