### PR TITLE
Fix symfony guzzle service container arguments

### DIFF
--- a/src/Resources/config/services/guzzle_client.yml
+++ b/src/Resources/config/services/guzzle_client.yml
@@ -10,7 +10,7 @@ services:
     anime_db.ani_db.browser.client.guzzle.guzzle:
         class: GuzzleHttp\Client
         arguments:
-            base_uri: '%anime_db.ani_db.api.host%'
+            - base_uri: '%anime_db.ani_db.api.host%'
         public: false
 
     anime_db.ani_db.browser.client.guzzle.request_configurator:


### PR DESCRIPTION
If use with symfony `^3.2` there will be an error
```
[Symfony\Component\Debug\Exception\ContextErrorException]
  Catchable Fatal Error: Argument 1 passed to GuzzleHttp\Client::__construct() must be of the type array, string given, called in ... and defined
```
cause after build service container will create such method
```
protected function getAnimeDb_AniDb_Browser_Client_GuzzleService()¬
{
    $a = new \AnimeDb\Bundle\AniDbBrowserBundle\Service\Client\Guzzle\RequestConfigurator();
    $a->setProtocolVersion(1);
    $a->setAppVersion(1);
    $a->setAppClient('XXX');
    $a->setAppCode('api-team-XXX');

    return $this->services['anime_db.ani_db.browser.client.guzzle'] = new \AnimeDb\Bundle\AniDbBrowserBundle\Service\Client\GuzzleClient(new \GuzzleHttp\Client('http://api.anidb.net:9001'), $a, new \AnimeDb\Bundle\AniDbBrowserBundle\Util\ResponseRepair(), '/httpapi');
}
```
where `GuzzleHttp\Client('http://api.anidb.net:9001')` will get string, but by specification it should get an hash array
```
// GuzzleHttp\Client
public function __construct(array $config = [])
    {
```
so arguments in `anime_db.ani_db.browser.client.guzzle.guzzle` should have `dash`
```
anime_db.ani_db.browser.client.guzzle.guzzle:
        class: GuzzleHttp\Client
        arguments:
            - base_uri: '%anime_db.ani_db.api.host%'
```
and here we got
```
new \GuzzleHttp\Client(array('base_uri' => 'http://api.anidb.net:9001')
```